### PR TITLE
updated to new environment_monitor_interface.h

### DIFF
--- a/twc_application/src/application_node.cpp
+++ b/twc_application/src/application_node.cpp
@@ -9,7 +9,7 @@
 #include <twc_application/raster_applicataion.h>
 
 using tesseract_environment::Environment;
-using tesseract_monitoring::EnvironmentMonitorInterface;
+using tesseract_monitoring::ROSEnvironmentMonitorInterface;
 
 static const std::string TOOLPATH = "twc_toolpath";
 
@@ -19,7 +19,7 @@ int main(int argc, char** argv)
   ros::NodeHandle nh, pnh("~");
 
   // Create a tesseract interface
-  EnvironmentMonitorInterface interface("tesseract_environment");
+  ROSEnvironmentMonitorInterface interface("tesseract_environment");
   interface.addNamespace("tesseract_workcell_environment");
   if (!interface.wait())
   {


### PR DESCRIPTION
I was getting the build error while compiling this repo. I mentioned the problem in [this](https://github.com/tesseract-robotics/tesseract_ros_workcell/issues/13) issue two days ago. I think the tesseract_ros package and other core packages in general are not in sync with tesseract_ros_workcell. This repo needs to be updated asap. Thanks!